### PR TITLE
Use algorithm value from constructor when generating OTP + update tests and reformat code

### DIFF
--- a/lib/src/hotp.dart
+++ b/lib/src/hotp.dart
@@ -22,17 +22,21 @@ class HOTP extends OTP {
   ///
   /// This constructor will create an HOTP instance.
   ///
-  /// All parameters are mandatory however [counter],
-  /// [digits] and [algorithm] have a default values, so can be ignored.
+  /// All parameters are mandatory however [counter], [digits]
+  /// and [algorithm] have a default value, so can be ignored.
   ///
   /// Will throw an exception if the line above isn't satisfied.
   ///
-  HOTP(
-      {required String secret,
-      this.counter = 0,
-      int digits = 6,
-      OTPAlgorithm? algorithm = OTPAlgorithm.SHA1})
-      : super(secret: secret, digits: digits, algorithm: algorithm!);
+  HOTP({
+    required String secret,
+    this.counter = 0,
+    int digits = 6,
+    OTPAlgorithm algorithm = OTPAlgorithm.SHA1,
+  }) : super(
+          secret: secret,
+          digits: digits,
+          algorithm: algorithm,
+        );
 
   ///
   /// Generate the HOTP value with the given count

--- a/lib/src/totp.dart
+++ b/lib/src/totp.dart
@@ -28,12 +28,16 @@ class TOTP extends OTP {
   ///
   /// Will throw an exception if the line above isn't satisfied.
   ///
-  TOTP(
-      {required String? secret,
-      int? digits = 6,
-      int interval = 30,
-      OTPAlgorithm algorithm = OTPAlgorithm.SHA1})
-      : super(secret: secret!, digits: digits!, algorithm: algorithm) {
+  TOTP({
+    required String secret,
+    int digits = 6,
+    int interval = 30,
+    OTPAlgorithm algorithm = OTPAlgorithm.SHA1,
+  }) : super(
+          secret: secret,
+          digits: digits,
+          algorithm: algorithm,
+        ) {
     this.interval = interval;
   }
 
@@ -46,8 +50,10 @@ class TOTP extends OTP {
   /// ```
   ///
   String now() {
-    int _formatTime =
-        Util.timeFormat(time: DateTime.now(), interval: interval!);
+    int _formatTime = Util.timeFormat(
+      time: DateTime.now(),
+      interval: interval!,
+    );
     return super.generateOTP(input: _formatTime);
   }
 

--- a/lib/src/utils/generic_util.dart
+++ b/lib/src/utils/generic_util.dart
@@ -29,11 +29,14 @@ abstract class Util {
   ///
   /// @return {List}
   ///
-  static List intToBytelist({int? input, int padding = 8}) {
+  static List<int> intToBytelist(
+    int input, {
+    int padding = 8,
+  }) {
     List<int> _result = [];
     var _input = input;
     while (_input != 0) {
-      _result.add(_input! & 0xff);
+      _result.add(_input & 0xff);
       _input >>= padding;
     }
     _result.addAll(List<int>.generate(padding, (_) => 0));

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -112,7 +112,7 @@ packages:
       name: http_multi_server
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.1"
+    version: "3.2.0"
   http_parser:
     dependency: transitive
     description:
@@ -140,7 +140,7 @@ packages:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.3"
+    version: "0.6.4"
   json_annotation:
     dependency: transitive
     description:
@@ -170,12 +170,12 @@ packages:
     source: hosted
     version: "0.12.10"
   meta:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.6.0"
   mime:
     dependency: transitive
     description:
@@ -287,7 +287,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   stack_trace:
     dependency: transitive
     description:
@@ -389,4 +389,4 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.14.0 <3.0.0"
+  dart: ">=2.16.0-100.0.dev <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,9 @@ dependencies:
   crypto: ^3.0.1
   base32: ^2.1.1
 
+dependency_overrides:
+  meta: 1.6.0 # bugfix for running tests: https://github.com/dart-lang/sdk/issues/46687#issuecomment-890541823
+
 dev_dependencies:
   test: ^1.16.5
   test_coverage:

--- a/test/hotp_test.dart
+++ b/test/hotp_test.dart
@@ -12,14 +12,13 @@ void main() {
     expect(hotp.algorithm, OTPAlgorithm.SHA1);
   });
 
-  test(
-      '[HOTP] Should check the token with custom digits, counter and algorithm',
-      () {
+  test('[HOTP] Should check the token with custom digits, counter and algorithm', () {
     var token = HOTP(
-        secret: "J22U6B3WIWRRBTAV",
-        digits: 8,
-        counter: 50,
-        algorithm: OTPAlgorithm.SHA256);
+      secret: "J22U6B3WIWRRBTAV",
+      digits: 8,
+      counter: 50,
+      algorithm: OTPAlgorithm.SHA256,
+    );
 
     expect(token.digits, 8);
     expect(token.counter, 50);
@@ -35,9 +34,21 @@ void main() {
     expect(hotp.verify(otp: otpValue, counter: 0), true);
   });
 
-  test(
-      '[HOTP] Should generate, verify using a specific counter and comare with a superior counter',
-      () {
+  test('[HOTP] Should generate using the given algorithm', () {
+    final h = HOTP(
+      secret: '3SO3CV7XVSRTLJPK',
+      algorithm: OTPAlgorithm.SHA512,
+      counter: 3,
+    );
+    final hotpAt = h.at(counter: 3);
+    final hotpGenerated = h.generateOTP(
+      input: 3,
+      algorithm: OTPAlgorithm.SHA512,
+    );
+    expect(hotpAt, hotpGenerated);
+  });
+
+  test('[HOTP] Should generate, verify using a specific counter and comare with a superior counter', () {
     var otpValue = hotp.at(counter: 10);
     expect(hotp.verify(otp: otpValue, counter: 10), true);
     expect(hotp.verify(otp: otpValue, counter: 20), false);
@@ -47,27 +58,22 @@ void main() {
     expect(hotp.generateUrl(issuer: "Sample", account: "Account"),
         "otpauth://hotp/Account?secret=J22U6B3WIWRRBTAV&issuer=Sample&digits=6&algorithm=SHA1&counter=0");
     expect(
-        hotp.generateUrl(issuer: "Encoded Issuer", account: "Account Detailed"),
-        "otpauth://hotp/Account%20Detailed?secret=J22U6B3WIWRRBTAV&issuer=Encoded+Issuer&digits=6&algorithm=SHA1&counter=0");
+      hotp.generateUrl(issuer: "Encoded Issuer", account: "Account Detailed"),
+      "otpauth://hotp/Account%20Detailed?secret=J22U6B3WIWRRBTAV&issuer=Encoded+Issuer&digits=6&algorithm=SHA1&counter=0",
+    );
   });
 
   test('[HOTP] Should generate token urls with a custom token', () {
     var token = HOTP(
-        secret: "J22U6B3WIWRRBTAV",
-        digits: 8,
-        counter: 10,
-        algorithm: OTPAlgorithm.SHA256);
-    expect(token.generateUrl(issuer: "More", account: "Digits"),
-        "otpauth://hotp/Digits?secret=J22U6B3WIWRRBTAV&issuer=More&digits=8&algorithm=SHA256&counter=10");
-  });
-
-  test('[HOTP] Fail Conditions: Init Asserts', () {
-    expect(() => HOTP(secret: ''),
-        throwsA(predicate((e) => e.toString().contains('secret != null'))));
-    expect(() => HOTP(secret: '', digits: 0),
-        throwsA(predicate((e) => e.toString().contains('digits != null'))));
-    expect(() => HOTP(secret: '', digits: 0, algorithm: null),
-        throwsA(predicate((e) => e.toString().contains('algorithm != null'))));
+      secret: "J22U6B3WIWRRBTAV",
+      digits: 8,
+      counter: 10,
+      algorithm: OTPAlgorithm.SHA256,
+    );
+    expect(
+      token.generateUrl(issuer: "More", account: "Digits"),
+      "otpauth://hotp/Digits?secret=J22U6B3WIWRRBTAV&issuer=More&digits=8&algorithm=SHA256&counter=10",
+    );
   });
 
   test('[HOTP] Fail Conditions: Validations', () {

--- a/test/totp_test.dart
+++ b/test/totp_test.dart
@@ -1,35 +1,53 @@
 import 'package:dart_dash_otp/dart_dash_otp.dart';
+import 'package:dart_dash_otp/src/utils/generic_util.dart';
 import 'package:test/test.dart';
 
 void main() {
   var totp = TOTP(secret: "J22U6B3WIWRRBTAV");
 
   test('[TOTP] Should check the token with default digits and interval', () {
-    expect(totp.digits, 6);
-    expect(totp.interval, 30);
     expect(totp.type, OTPType.TOTP);
     expect(totp.secret, "J22U6B3WIWRRBTAV");
+    expect(totp.digits, 6);
+    expect(totp.interval, 30);
     expect(totp.algorithm, OTPAlgorithm.SHA1);
   });
 
-  test(
-      '[TOTP] Should check the token with custom digits, interval and algorithm',
-      () {
+  test('[TOTP] Should check the token with custom digits, interval and algorithm', () {
     var token = TOTP(
-        secret: "J22U6B3WIWRRBTAV",
-        digits: 8,
-        interval: 60,
-        algorithm: OTPAlgorithm.SHA256);
+      secret: "J22U6B3WIWRRBTAV",
+      digits: 8,
+      interval: 60,
+      algorithm: OTPAlgorithm.SHA256,
+    );
 
-    expect(token.digits, 8);
-    expect(token.interval, 60);
     expect(token.type, OTPType.TOTP);
     expect(token.secret, "J22U6B3WIWRRBTAV");
+    expect(token.digits, 8);
+    expect(token.interval, 60);
     expect(token.algorithm, OTPAlgorithm.SHA256);
   });
 
   test('[TOTP] Should generate the token using current time', () {
     expect(totp.now(), isNotNull);
+  });
+
+  test('[TOTP] Should generate the token using the given algorithm', () {
+    final secret = '3SO3CV7XVSRTLJPK';
+    TOTP t = TOTP(
+      secret: secret,
+      algorithm: OTPAlgorithm.SHA256,
+      interval: 60,
+    );
+    final totpNow = t.now();
+    final totpGenerated = t.generateOTP(
+      algorithm: OTPAlgorithm.SHA256,
+      input: Util.timeFormat(
+        time: DateTime.now(),
+        interval: 60,
+      ),
+    );
+    expect(totpNow, totpGenerated);
   });
 
   test('[TOTP] Should generate and verify using a specific date time', () {
@@ -39,13 +57,11 @@ void main() {
     expect(totp.verify(otp: otpValue, time: time), true);
   });
 
-  test(
-      '[TOTP] Should generate, verify hard coded date time and compare to current time (should be false)',
-      () {
+  test('[TOTP] Should generate, verify hard coded date time and compare to current time (should be false)', () {
     var time = DateTime.parse('2019-01-01 00:00:00.000');
     var otpValue = totp.value(date: time);
 
-    expect(otpValue, '793957');
+    expect(otpValue, '734632');
     expect(totp.verify(otp: otpValue), false);
     expect(totp.verify(otp: otpValue, time: time), true);
   });
@@ -54,27 +70,22 @@ void main() {
     expect(totp.generateUrl(issuer: "Sample", account: "Account"),
         "otpauth://totp/Account?secret=J22U6B3WIWRRBTAV&issuer=Sample&digits=6&algorithm=SHA1&period=30");
     expect(
-        totp.generateUrl(issuer: "Encoded Issuer", account: "Account Detailed"),
-        "otpauth://totp/Account%20Detailed?secret=J22U6B3WIWRRBTAV&issuer=Encoded+Issuer&digits=6&algorithm=SHA1&period=30");
+      totp.generateUrl(issuer: "Encoded Issuer", account: "Account Detailed"),
+      "otpauth://totp/Account%20Detailed?secret=J22U6B3WIWRRBTAV&issuer=Encoded+Issuer&digits=6&algorithm=SHA1&period=30",
+    );
   });
 
   test('[HOTP] Should generate token urls with a custom token', () {
     var token = TOTP(
-        secret: "J22U6B3WIWRRBTAV",
-        digits: 8,
-        interval: 60,
-        algorithm: OTPAlgorithm.SHA256);
-    expect(token.generateUrl(issuer: "More", account: "Digits"),
-        "otpauth://totp/Digits?secret=J22U6B3WIWRRBTAV&issuer=More&digits=8&algorithm=SHA256&period=60");
-  });
-
-  test('[TOTP] Fail Conditions: Init Asserts', () {
-    expect(() => TOTP(secret: null),
-        throwsA(predicate((e) => e.toString().contains('secret != null'))));
-    expect(() => TOTP(secret: '', digits: null),
-        throwsA(predicate((e) => e.toString().contains('digits != null'))));
-    expect(() => HOTP(secret: '', digits: 0, algorithm: null),
-        throwsA(predicate((e) => e.toString().contains('algorithm != null'))));
+      secret: "J22U6B3WIWRRBTAV",
+      digits: 8,
+      interval: 60,
+      algorithm: OTPAlgorithm.SHA256,
+    );
+    expect(
+      token.generateUrl(issuer: "More", account: "Digits"),
+      "otpauth://totp/Digits?secret=J22U6B3WIWRRBTAV&issuer=More&digits=8&algorithm=SHA256&period=60",
+    );
   });
 
   test('[TOTP] Fail Conditions: Validations', () {

--- a/test/utils/generic_util_test.dart
+++ b/test/utils/generic_util_test.dart
@@ -6,22 +6,22 @@ void main() {
     var time = DateTime.parse('2019-01-01 00:00:00.000');
     var formatTime = Util.timeFormat(time: time, interval: 30);
 
-    expect(formatTime, 51543360);
+    expect(formatTime, 51543240);
   });
 
   test('[Util] Should time format with 60 second interval', () {
     var time = DateTime.parse('2019-01-01 00:00:00.000');
     var formatTime = Util.timeFormat(time: time, interval: 60);
 
-    expect(formatTime, 25771680);
+    expect(formatTime, 25771620);
   });
 
   test('[Util] Should convert time format into byte list', () {
-    var byteList = Util.intToBytelist(input: 25771680);
+    var byteList = Util.intToBytelist(25771680);
 
     expect(byteList.length, 8);
 
-    byteList = Util.intToBytelist(input: 51543360, padding: 6);
+    byteList = Util.intToBytelist(51543360, padding: 6);
 
     expect(byteList.length, 6);
   });


### PR DESCRIPTION
### Issue: specifying an algorithm other than `SHA1` in `TOTP` constructor doesn't make any difference when generating OTPs.

Currently, if you want to use any algorithm other than the default one (`SHA1`), you must specify it in the `generateOTP` method, because `generateOTP`'s `algorithm` param defaults to `OTPAlgorithm.SHA1`, no matter what is specified in the TOTP constructor. So, to generate a valid `SHA256` OTP, you have to do this:
```dart
    // ...
    return TOTP(
      secret: secret,
      digits: digits,
      interval: interval,
      algorithm: algorithm, // doesn't make any difference whatever I pass here
    ).generateOTP(
      algorithm: OTPAlgorithm.SHA256, // this is what counts
      input: Util.timeFormat(
        time: DateTime.now(),
        interval: interval,
      ),
    );
```